### PR TITLE
fgci-centos7-generic: anaconda/2020-05-tf2

### DIFF
--- a/configs/fgci-centos7-generic/anaconda/build_config.yaml
+++ b/configs/fgci-centos7-generic/anaconda/build_config.yaml
@@ -126,6 +126,7 @@ environments:
     miniconda: True
     python_version: 3
     installer_version: 'py37_4.8.2'
+    freeze: True
     condarc:
       channels:
         - pytorch
@@ -138,8 +139,23 @@ environments:
     collections:
       - tensorflow-v2
       - triton-generic
-collections:
-  tensorflow-v1:
+  - name: anaconda
+    version: '2020-05-tf2'
+    miniconda: True
+    python_version: 3
+    installer_version: 'py37_4.8.2'
+    condarc:
+      channels:
+        - pytorch
+        - defaults
+        - gurobi
+        - IBMDecisionOptimization
+        - mosek
+        - rapidsai
+        - conda-forge
+    collections:
+      - tensorflow-v2
+      - triton-generic
 collections:
   tensorflow-v1:
     conda_packages:
@@ -328,7 +344,7 @@ collections:
       - python-dateutil
       - python-libarchive-c
       - python-snappy
-      - pytorch=1.5.*
+      - pytorch=1.7.*
       - pytz
       - pyyaml
       - requests


### PR DESCRIPTION
Adding anaconda/2020-05-tf2 with newer version of pytorch to the build.