### PR TITLE
fgci-centos7-anaconda: Adding torchvision-package

### DIFF
--- a/configs/fgci-centos7-anaconda/anaconda/build_config.yaml
+++ b/configs/fgci-centos7-anaconda/anaconda/build_config.yaml
@@ -148,6 +148,7 @@ collections:
      - spyder
      - sympy
      - theano
+     - torchvision
      - twisted
      - typing
      - unicodecsv


### PR DESCRIPTION
This PR adds torchvision to base anaconda environments.