### PR TITLE
fgci-centos7-haswell: geant4 & gsl v. 2.6

### DIFF
--- a/configs/fgci-centos7-haswell/spack/build_config.yaml
+++ b/configs/fgci-centos7-haswell/spack/build_config.yaml
@@ -97,3 +97,10 @@ packages:
       - '+blas'
       - '+mpi'
       - '+openmp'
+  - name: 'gsl'
+    version: '2.6'
+  - name: 'geant4'
+    version: '10.7.1'
+    variants:
+      - '+ipo'
+      - '+python'


### PR DESCRIPTION
These packages are already in the dev builds and the user seems happy with these.

https://version.aalto.fi/gitlab/AaltoScienceIT/triton/issues/210 

