### PR TITLE
adding libxscrnsaver 1.2.2 to fix triton issue 985

### DIFF
--- a/configs/fgci-centos7-haswell-dev/spack/build_config.yaml
+++ b/configs/fgci-centos7-haswell-dev/spack/build_config.yaml
@@ -156,3 +156,5 @@ packages:
     version: '2.6'
   - name: 'libsvm'
     version: '323'
+  - name: 'libxscrnsaver'
+    version: '1.2.2'

--- a/configs/fgci-centos7-haswell-dev/spack/packages.yaml
+++ b/configs/fgci-centos7-haswell-dev/spack/packages.yaml
@@ -20,8 +20,6 @@ packages:
     variants: +cxx +fortran +hl +pic +shared +szip +threadsafe
   latte:
     variants: +progress
-  libxscrnsaver:
-    version: [1.2.2]
   llvm:
     variants: +python
   m4:

--- a/configs/fgci-centos7-haswell-dev/spack/packages.yaml
+++ b/configs/fgci-centos7-haswell-dev/spack/packages.yaml
@@ -20,6 +20,8 @@ packages:
     variants: +cxx +fortran +hl +pic +shared +szip +threadsafe
   latte:
     variants: +progress
+  libxscrnsaver:
+    version: [1.2.2]
   llvm:
     variants: +python
   m4:


### PR DESCRIPTION
I am unsure if this is the right place to add it, but this is why this is a pull request :)
https://spack.readthedocs.io/en/latest/package_list.html#libxscrnsaver