### PR TITLE
fgci-centos7-haswell: Add nvhpc 21.5 to the software stack

### DIFF
--- a/configs/fgci-centos7-haswell/spack/build_config.yaml
+++ b/configs/fgci-centos7-haswell/spack/build_config.yaml
@@ -108,3 +108,5 @@ packages:
     version: '1.6.1'
     extra_flags:
       - '-j 1'
+  - name: 'nvhpc'
+    version: '21.5'


### PR DESCRIPTION
This PR adds nvhpc to the default software stack.