### PR TITLE
fgci-centos7-anaconda-dev: Add ipympl

### DIFF
--- a/configs/fgci-centos7-anaconda-dev/anaconda/build_config.yaml
+++ b/configs/fgci-centos7-anaconda-dev/anaconda/build_config.yaml
@@ -219,6 +219,7 @@ collections:
       - importnb
       - iniconfig
       - ipdb
+      - ipympl    # jupyter + matplotlib interactive
       - jbig
       - joblib
       - jupyter


### PR DESCRIPTION
- Jupyter + matplotlib interactive
- This requires jupyterlab >= 3 as it is now, which we don't have yet,
  but adding it now prepares for the future.