### PR TITLE
mriqc with new builder

### DIFF
--- a/configs/fgci-centos7-singularity-dev/singularity/build_config.yaml
+++ b/configs/fgci-centos7-singularity-dev/singularity/build_config.yaml
@@ -163,3 +163,13 @@ definitions:
       - 'common'
     flag_collections:
       - 'common'
+  - name: 'singularity-mriqc'
+    docker_user: 'poldracklab'
+    docker_image: 'mriqc'
+    module_namespace: 'common'
+    tags:
+      - '0.16.1'
+    command_collections:
+      - 'common'
+    flag_collections:
+      - 'common'


### PR DESCRIPTION
adding mriqc from dockerhub, we had it with the old singularity builder I can test it with the new one.