### PR TITLE
fgci-centos7-haswell: Add netcdf-cxx4 to the production build

### DIFF
--- a/configs/fgci-centos7-haswell/spack/build_config.yaml
+++ b/configs/fgci-centos7-haswell/spack/build_config.yaml
@@ -116,3 +116,5 @@ packages:
     version: '16.7.6'
   - name: 'flac'
     version: '1.3.3'
+  - name: 'netcdf-cxx4'
+    version: '4.3.1'


### PR DESCRIPTION
This PR adds netcdf-cxx4 to the production build.