### PR TITLE
fgci-centos7-haswell: Adding jq@1.6 to the build

### DIFF
--- a/configs/fgci-centos7-haswell/spack/build_config.yaml
+++ b/configs/fgci-centos7-haswell/spack/build_config.yaml
@@ -129,3 +129,5 @@ packages:
     variants:
       - '+openmp'
       - '+pic'
+  - name: 'jq'
+    version: '1.6'


### PR DESCRIPTION
This PR adds jq@1.6 to the build.