### PR TITLE
fgci-centos7-anaconda: New environments for tensorflow, pytorch and rapidsai

### DIFF
--- a/configs/fgci-centos7-anaconda/anaconda/build_config.yaml
+++ b/configs/fgci-centos7-anaconda/anaconda/build_config.yaml
@@ -1,6 +1,8 @@
 installer_checksums:
   Miniconda3-py37_4.9.2-Linux-x86_64.sh: '79510c6e7bd9e012856e25dcb21b3e093aa4ac8113d9aa7e82a86987eabe1c31'
   Miniconda3-py38_4.9.2-Linux-x86_64.sh: '1314b90489f154602fd794accfc90446111514a5a72fe1f71ab83e07de9504a7'
+  Miniconda3-py38_4.10.3-Linux-x86_64.sh: '935d72deb16e42739d69644977290395561b7a6db059b316958d97939e9bdf3d'
+  Miniconda3-py39_4.10.3-Linux-x86_64.sh: '1ea2f885b4dbc3098662845560bc64271eb17085387a70c2ba3f29fff6f8d52f'
 environments:
   - name: miniconda
     version: '4.9.2'
@@ -53,6 +55,7 @@ environments:
     miniconda: True
     python_version: 3
     installer_version: 'py38_4.9.2'
+    freeze: True
     condarc:
       channels:
         - pytorch
@@ -66,6 +69,75 @@ environments:
     collections:
       - tensorflow-v2
       - triton-generic
+    extra_module_variables:
+      setenv:
+        GUROBI_HOME: '$prefix'
+  - name: pytorch
+    version: '1.9.1'
+    miniconda: True
+    python_version: 3
+    installer_version: 'py38_4.10.3'
+    condarc_install:
+      channels:
+        - pytorch
+        - nvidia
+        - conda-forge
+        - gurobi
+        - IBMDecisionOptimization
+        - mosek
+      channel_priority: strict
+    collections:
+      - triton-generic
+      - pytorch
+      - mne
+      - gurobi
+      - cplex
+      - mosek
+    extra_module_variables:
+      setenv:
+        GUROBI_HOME: '$prefix'
+  - name: tensorflow
+    version: '2.6.0'
+    miniconda: True
+    python_version: 3
+    installer_version: 'py38_4.10.3'
+    condarc_install:
+      channels:
+        - conda-forge
+        - gurobi
+        - IBMDecisionOptimization
+        - mosek
+      channel_priority: strict
+    collections:
+      - tensorflow-v2-pip
+      - triton-generic
+      - mne
+      - gurobi
+      - cplex
+      - mosek
+    extra_module_variables:
+      setenv:
+        GUROBI_HOME: '$prefix'
+  - name: rapidsai
+    version: '21.10'
+    miniconda: True
+    python_version: 3
+    installer_version: 'py38_4.10.3'
+    condarc_install:
+      channels:
+        - rapidsai
+        - nvidia
+        - conda-forge
+        - gurobi
+        - IBMDecisionOptimization
+        - mosek
+      channel_priority: flexible
+    collections:
+      - rapidsai
+      - triton-generic
+      - gurobi
+      - cplex
+      - mosek
     extra_module_variables:
       setenv:
         GUROBI_HOME: '$prefix'
@@ -93,6 +165,18 @@ environments:
     collections:
       - neuroimaging
 collections:
+  cplex:
+    conda_packages:
+      - cplex
+  gurobi:
+    conda_packages:
+      - gurobi
+  gurobipy:
+    pip_packages:
+      - gurobipy
+  mosek:
+    conda_packages:
+      - mosek
   tensorflow-v1:
     conda_packages:
       - tensorboard
@@ -103,12 +187,66 @@ collections:
       - tensorflow-gpu
   tensorflow-v2:
     conda_packages:
+      - cudatoolkit
       - tensorboard
       - tensorboard-plugin-wit
       - tensorflow=2.4.*=gpu_*
       - tensorflow-base
       - tensorflow-estimator
       - tensorflow-gpu
+  tensorflow-v2-pip:
+    # Check this page for compatible versions of tensorflow, cudatoolkit and cudnn.
+    # https://www.tensorflow.org/install/source#gpu
+    conda_packages:
+      - absl-py
+      - astunparse
+      - cudatoolkit=11.2.*
+      - cudatoolkit-dev=11.2.*
+      - cudnn=8.1.*
+      - gast
+      - google-pasta
+      - grpcio
+      - h5py
+      - keras-preprocessing
+      - libgcc-ng
+      - libstdcxx-ng
+      - numpy
+      - opt_einsum
+      - protobuf
+      - python-flatbuffers
+      - scipy
+      - six
+      - sqlite
+      - termcolor
+      - wrapt
+      - zlib
+    pip_packages:
+      - tensorflow==2.6.0
+  rapidsai:
+    conda_packages:
+      - cudatoolkit=11.4
+      - cudf
+      - cuml
+      - cugraph
+      - cusignal
+      - cuspatial
+      - cuxfilter
+      - rapids-blazing=21.10
+  pytorch:
+    conda_packages:
+      - cudatoolkit=11.*
+      - pytorch=1.9.1=*cuda11*
+      - torchaudio
+      # torchvision dependencies
+      - ffmpeg
+      - jpeg
+      - libpng
+      - pillow
+    pip_packages:
+      - torchvision==0.10.1
+  mne:
+    conda_packages:
+      - mne
   triton-generic:
     pip_packages:
       - bash-kernel
@@ -130,7 +268,6 @@ collections:
       - bcolz
       - beautifulsoup4
       - bitarray
-      - bkcharts
       # - blaze # No python3.8 build
       - boto
       - bottleneck
@@ -138,15 +275,8 @@ collections:
       - conda-tree
       - configargparse
       - contextlib2
-      - cplex
-      - cudatoolkit=10.*
-      - cudf
-      - cuml
-      - cugraph
-      - cusignal
-      - cuspatial
-      - cuxfilter
       - cython
+      - dask
       - datalad
       - dill
       - docopt
@@ -155,26 +285,23 @@ collections:
       - glob2
       - gpy
       - greenlet
-      - gurobi
       - html5lib
       - importnb
       - iniconfig
       - ipdb
+      - ipympl    # jupyter + matplotlib interactive
       - jbig
       - joblib
       - jupyter
       - jupyter_contrib_nbextensions
       - jupyterlab
       - jupytext
-      - keras
       - libblas=*=*mkl*
       - librosa
       - libxscrnsaver-cos6-x86_64
       - line_profiler
       - metakernel
-      - mne
       - more-itertools
-      - mosek
       - mpi4py
       - nbdime
       - nbstripout
@@ -183,7 +310,6 @@ collections:
       - nltk
       - nose
       - numpy
-      - openmp
       - openpyxl
       - pango
       - patchelf
@@ -207,11 +333,8 @@ collections:
       - pytest-astropy
       - python-libarchive-c
       - python-snappy
-      - python=3.8.*
-      - pytorch=1.8.1=*cuda*
       - ripgrep
       - scikit-image
-      - seaborn
       - sh
       - simplegeneric
       - singledispatch
@@ -221,9 +344,6 @@ collections:
       - spyder
       - spyder-line-profiler
       - sympy
-      - theano
-      - torchvision
-      - torchaudio
       - twisted
       - typing
       - unicodecsv


### PR DESCRIPTION
This PR adds three new environments:
1. `tensorflow/2.6.0` with Tensorflow installed from PIP
2. `pytorch/1.9.1` with pytorch installed from pytorch-channel
3. `rapidsai/21.10` installed from rapidsai-channel

These environments share common packages, but they are incompatible with each other due to conflicting `cudatoolkit` requirements.