### PR TITLE
fgci-centos7-haswell: Add libgd@2.2.4 to the build

### DIFF
--- a/configs/fgci-centos7-haswell/spack/build_config.yaml
+++ b/configs/fgci-centos7-haswell/spack/build_config.yaml
@@ -138,3 +138,5 @@ packages:
     version: '1.6'
   - name: 'p7zip'
     version: '16.02'
+  - name: 'libgd'
+    version: '2.2.4'


### PR DESCRIPTION
This PR adds libgd@2.2.4 to the build.