### PR TITLE
sync.sh: make diff configurable, better documentation

### DIFF
--- a/sync.sh
+++ b/sync.sh
@@ -4,20 +4,27 @@
 # do   move code <-  (get)
 # ]c   jump next  ( [c  jump previous )
 
+DIFF=${DIFF:-vimdiff}
 
 case $1 in
   triton)
-    vimdiff configs/fgci-centos7-{dev,generic}/anaconda/build_config.yaml
+    $DIFF configs/fgci-centos7-{dev,generic}/anaconda/build_config.yaml
     ;;
   fgci)
-    vimdiff configs/{fgci-centos7-generic,fgi-cvmfs-centos7-generic}/anaconda/build_config.yaml
+    $DIFF configs/{fgci-centos7-generic,fgci-cvmfs-centos7-generic}/anaconda/build_config.yaml
     ;;
   aaltodev)
-    vimdiff configs/{fgci-centos7-dev,aalto-ubuntu1804-dev}/anaconda/build_config.yaml
+    $DIFF configs/{fgci-centos7-dev,aalto-ubuntu1804-dev}/anaconda/build_config.yaml
     ;;
   aalto)
-    vimdiff configs/aalto-ubuntu1804-{dev,generic}/anaconda/build_config.yaml
+    $DIFF configs/aalto-ubuntu1804-{dev,generic}/anaconda/build_config.yaml
     ;;
   *)
-    echo "options: triton,fgci.  aaltodev, aalto"
+      echo "Automatically diff different anaconda build config files"
+      echo "Options:"
+      echo "  triton, fgci, aaltodev, aalto"
+      echo "Run these roughly in this order to propagate configs from"
+      echo "fgci-centos-7-dev to all other configs".
+      echo
+      echo "To use a different diff tool, set DIFF".
  esac


### PR DESCRIPTION
- sync.sh was used to easily diff and move changes between versions
- So you can run e.g. `DIFF=meld bash sync.sh triton` to graphically
  merge things over.
