### PR TITLE
fgci-centos7-haswell: Add intel-oneapi-compilers and intel-oneapi-mkl

### DIFF
--- a/configs/fgci-centos7-haswell/spack/build_config.yaml
+++ b/configs/fgci-centos7-haswell/spack/build_config.yaml
@@ -66,6 +66,18 @@ compilers:
       platform: linux
       os: centos7
       arch: x86_64
+  - name: 'intel-oneapi-compilers'
+    version: '2021.3.0'
+    dependencies:
+      - '%gcc@4.8.5'
+    flags:
+      cflags: -O2 -g -march=haswell
+      cxxflags: -O2 -g -march=haswell
+      fflags: -O2 -g -march=haswell
+    target_architecture:
+      platform: linux
+      os: centos7
+      arch: x86_64
 packages:
   - name: 'abinit'
     version: '8.10.3'
@@ -156,3 +168,5 @@ packages:
     version: '16.02'
   - name: 'libgd'
     version: '2.2.4'
+  - name: 'intel-oneapi-mkl'
+    version: '2021.3.0'


### PR DESCRIPTION
This PR adds intel-oneapi-compilers and intel-oneapi-mkl versions 2021.3.0 to the build.